### PR TITLE
doctest readme with tox on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: python
+
+python:
+  - 2.7
+  - 3.4
+  - 3.5
+  - 3.6
+  - 3.7
+  - pypy
+  - pypy3
+
+before_install:
+
+install:
+  - pip install tox tox-travis
+
+script:
+  - tox
+
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,10 @@
 language: python
 
 python:
-  - 2.7
-  - 3.4
   - 3.5
   - 3.6
   - 3.7
-  - pypy
+  - 3.8
   - pypy3
 
 before_install:

--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,9 @@ functionality except support for "async def" functions.
 
 Preconditions and Postconditions
 ================================
+
+    >>> from dpcontracts import require, ensure
+
 Contracts on functions consist of preconditions and postconditions.
 A precondition is declared using the `requires` decorator, and describes
 what must be true upon entrance to the function. The condition function
@@ -67,7 +70,7 @@ with a PreconditionError (a subtype of AssertionError):
 
     >>> add2("foo", 2)
     Traceback (most recent call last):
-    PreconditionError: `i` must be an integer
+    dpcontracts.PreconditionError: `i` must be an integer
 
 Functions can also have postconditions, specified using the `ensure`
 decorator.  Postconditions describe what must be true after the function
@@ -95,7 +98,7 @@ Except that the function is broken in unexpected ways:
 
     >>> add2(7, 4)
     Traceback (most recent call last):
-    PostconditionError: the result must be greater than either `i` or `j`
+    dpcontracts.PostconditionError: the result must be greater than either `i` or `j`
 
 The function specifying the condition doesn't have to be a lambda; it can be
 any function, and pre- and postconditions don't have to actually reference
@@ -118,10 +121,10 @@ the function's environments and effects:
     >>> add_to_database("Marvin")
     >>> add_to_database("Marvin")
     Traceback (most recent call last):
-    PreconditionError: `name` must not already be in the database
+    dpcontracts.PreconditionError: `name` must not already be in the database
     >>> add_to_database("Rob")
     Traceback (most recent call last):
-    PostconditionError: the normalized version of the name must be added to the database
+    dpcontracts.PostconditionError: the normalized version of the name must be added to the database
 
 All of the various calling conventions of Python are supported:
 
@@ -146,6 +149,8 @@ A common contract is to validate the types of arguments. To that end,
 there is an additional decorator, `types`, that can be used
 to validate arguments' types:
 
+    >>> from dpcontracts import types
+
     >>> class ExampleClass:
     ...     pass
 
@@ -159,11 +164,11 @@ to validate arguments' types:
 
     >>> func(1.0, "foo", ExampleClass) # invalid type for `a`
     Traceback (most recent call last):
-    PreconditionError: the types of arguments must be valid
+    dpcontracts.PreconditionError: the types of arguments must be valid
 
     >>> func(1, "foo") # invalid type (the default) for `c`
     Traceback (most recent call last):
-    PreconditionError: the types of arguments must be valid
+    dpcontracts.PreconditionError: the types of arguments must be valid
 
 Contracts on Classes
 ====================
@@ -181,7 +186,7 @@ not just bare functions:
 
     >>> foo = Foo("")
     Traceback (most recent call last):
-    PreconditionError: `name` should be nonempty
+    dpcontracts.PreconditionError: `name` should be nonempty
 
 Classes may also have an additional sort of contract specified over them:
 the invariant.  An invariant, created using the `invariant` decorator,
@@ -189,6 +194,8 @@ specifies a condition that must always be true for instances of that class.
 In this case, "always" means "before invocation of any method and after
 its return" -- methods are allowed to violate invariants so long as they
 are restored prior to return.
+
+    >>> from dpcontracts import invariant
 
 Invariant contracts are passed a single variable, a reference to the
 instance of the class. For example:
@@ -222,11 +229,11 @@ instance of the class. For example:
     >>> nl.pop()
     >>> nl.pop()
     Traceback (most recent call last):
-    PostconditionError: inner list can never be empty
+    dpcontracts.PostconditionError: inner list can never be empty
 
     >>> nl = NonemptyList(["a", "b", "c"])
     Traceback (most recent call last):
-    PostconditionError: inner list must consist only of integers
+    dpcontracts.PostconditionError: inner list must consist only of integers
 
 Violations of invariants are ignored in the following situations:
 
@@ -265,7 +272,7 @@ For example:
     >>> x.break_everything()
     >>> x.get_always()
     Traceback (most recent call last):
-    PreconditionError: `always` should be True
+    dpcontracts.PreconditionError: `always` should be True
 
 Also note that if a method invokes another method on the same object,
 all of the invariants will be tested again:
@@ -295,7 +302,7 @@ This works well in most situations:
     6
     >>> my_func([0, -1, 2])
     Traceback (most recent call last):
-    PreconditionError: every item in `l` must be > 0
+    dpcontracts.PreconditionError: every item in `l` must be > 0
 
 But it fails in the case of a generator:
 
@@ -318,6 +325,8 @@ language, the compiler can verify that some properties of infinite lists
 We get around that limitation here using an additional decorator, called
 `transform` that transforms the arguments to a function, and a function
 called `rewrite` that rewrites argument tuples.
+
+    >>> from dpcontracts import transform, rewrite
 
 For example:
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,25 @@
+[tox]
+envlist = py27, py34, py35, py36, py37, pypy, pypy3
+skip_missing_interpreters=true
+
+[travis]
+2.7 = py27
+3.4 = py34
+3.5 = py35
+3.6 = py36
+3.7 = py37
+pypy = pypy
+pypy3 = pypy3
+
+[testenv]
+passenv = CI TRAVIS TRAVIS_*
+
+# to always force recreation and avoid unexpected side effects
+recreate = True
+
+deps = pytest
+
+commands = python -m pytest --
+
+[pytest]
+addopts = --doctest-modules

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,12 @@
 [tox]
-envlist = py27, py34, py35, py36, py37, pypy, pypy3
+envlist = py35, py36, py37, py38, pypy3
 skip_missing_interpreters=true
 
 [travis]
-2.7 = py27
-3.4 = py34
 3.5 = py35
 3.6 = py36
 3.7 = py37
-pypy = pypy
+3.8 = py38
 pypy3 = pypy3
 
 [testenv]
@@ -19,7 +17,5 @@ recreate = True
 
 deps = pytest
 
-commands = python -m pytest --
+commands = python -m pytest README.rst
 
-[pytest]
-addopts = --doctest-modules


### PR DESCRIPTION
Testing documentation on python3 supported versions, with tox on travis setup.
Still might need some refinements (see #12).
And there is the [3.7](https://github.com/travis-ci/travis-ci/issues/9815) and [3.8-dev](https://docs.travis-ci.com/user/languages/python/#specifying-python-versions) config to tune.